### PR TITLE
Er/matchmaking shortcut

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -69,7 +69,7 @@ private:
   void SetDefaultISO();
   void DeleteFile();
 #ifdef _WIN32
-  bool AddShortcutToDesktop();
+  bool AddShortcutToDesktop( bool matchmaking );
 #endif
   void InstallWAD();
   void UninstallWAD();

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -47,7 +47,7 @@ public:
 
   void PurgeCache();
 
-  const GameListModel& GetGameListModel() const { return m_model; }
+  GameListModel& GetGameListModel() { return m_model; }
 
 signals:
   void GameSelected();

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -472,3 +472,8 @@ void GameListModel::PurgeCache()
 {
   m_tracker.PurgeCache();
 }
+
+UICommon::GameFileCache& GameListModel::GetGameCache()
+{
+  return m_tracker.GetGameCache();
+}

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -364,15 +364,13 @@ std::shared_ptr<const UICommon::GameFile> GameListModel::FindGame(const std::str
   return index < 0 ? nullptr : m_games[index];
 }
 
-#include <iostream>
 int GameListModel::FindGameIndex(const std::string& path) const
 {
   for (int i = 0; i < m_games.size(); i++)
   {
-    auto gamePath = m_games[i]->GetFilePath();
-    std::cout << gamePath;
+    const auto gamePath = m_games[i]->GetFilePath();
 
-    if (gamePath == path)
+    if (StringToPath(gamePath) == StringToPath(path))
       return i;
   }
   return -1;

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -473,7 +473,8 @@ void GameListModel::PurgeCache()
   m_tracker.PurgeCache();
 }
 
-UICommon::GameFileCache& GameListModel::GetGameCache()
+std::shared_ptr<const UICommon::GameFile> GameListModel::AddOrGetFromCache(const std::string& path)
 {
-  return m_tracker.GetGameCache();
+  bool cacheChanged{};
+  return m_tracker.GetGameCache().AddOrGet(path, &cacheChanged);
 }

--- a/Source/Core/DolphinQt/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt/GameList/GameListModel.h
@@ -19,6 +19,7 @@
 namespace UICommon
 {
 class GameFile;
+class GameFileCache;
 }
 
 class GameListModel final : public QAbstractTableModel
@@ -82,6 +83,7 @@ public:
   void DeleteTag(const QString& name);
 
   void PurgeCache();
+  UICommon::GameFileCache& GetGameCache();
 
 private:
   // Index in m_games, or -1 if it isn't found

--- a/Source/Core/DolphinQt/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt/GameList/GameListModel.h
@@ -83,7 +83,7 @@ public:
   void DeleteTag(const QString& name);
 
   void PurgeCache();
-  UICommon::GameFileCache& GetGameCache();
+  std::shared_ptr<const UICommon::GameFile> AddOrGetFromCache(const std::string& path);
 
 private:
   // Index in m_games, or -1 if it isn't found

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -365,3 +365,8 @@ void GameTracker::PurgeCache()
   m_needs_purge = true;
   Settings::Instance().RefreshGameList();
 }
+
+UICommon::GameFileCache& GameTracker::GetGameCache()
+{
+  return m_cache;
+}

--- a/Source/Core/DolphinQt/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt/GameList/GameTracker.h
@@ -42,6 +42,7 @@ public:
   void RemoveDirectory(const QString& dir);
   void RefreshAll();
   void PurgeCache();
+  UICommon::GameFileCache& GetGameCache();
 
 signals:
   void GameLoaded(const std::shared_ptr<const UICommon::GameFile>& game);

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -238,8 +238,9 @@ int main(int argc, char* argv[])
   {
     DolphinAnalytics::Instance().ReportDolphinStart("qt");
 
-    auto mm_launcher = std::string(options.get("matchmaking"));
-    MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie")), std::move(mm_launcher)};
+    auto matchmaking_game_path = std::string(options.get("matchmaking"));
+    MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie")),
+                   std::move(matchmaking_game_path)};
     Settings::Instance().SetCurrentUserStyle(Settings::Instance().GetCurrentUserStyle());
     if (options.is_set("debugger"))
       Settings::Instance().SetDebugModeEnabled(true);

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -238,7 +238,8 @@ int main(int argc, char* argv[])
   {
     DolphinAnalytics::Instance().ReportDolphinStart("qt");
 
-    MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie"))};
+    auto mm_launcher = std::string(options.get("matchmaking"));
+    MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie")), std::move(mm_launcher)};
     Settings::Instance().SetCurrentUserStyle(Settings::Instance().GetCurrentUserStyle());
     if (options.is_set("debugger"))
       Settings::Instance().SetDebugModeEnabled(true);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -2114,8 +2114,18 @@ void MainWindow::Show()
   }
   else if (!m_init_netplay_path.empty())
   {
-    //TODO: fix according to rapito's fix to null reference thing
-    auto game = m_game_list->FindGame(m_init_netplay_path);
-    NetPlaySearch(*game);
+
+    const auto game = m_game_list->FindGame(m_init_netplay_path);
+    if (game)
+    {
+      NetPlaySearch(*game);
+    }
+    else
+    {
+      ModalMessageBox::critical(
+          nullptr, QStringLiteral("Error"),
+          QStringLiteral("Unable to start matchmaking with %1. Ensure the file exists.")
+              .arg(QString::fromStdString(m_init_netplay_path)));
+    }
   }
 }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -2114,7 +2114,8 @@ void MainWindow::Show()
   }
   else if (!m_init_netplay_path.empty())
   {
-
+    //TODO: don't find game from game list here, find directly in GameFileCache?
+    // Want to load game whether it's folder has been added to game list or not
     const auto game = m_game_list->FindGame(m_init_netplay_path);
     if (game)
     {

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -117,6 +117,7 @@
 
 #include "UICommon/DiscordPresence.h"
 #include "UICommon/GameFile.h"
+#include "UICommon/GameFileCache.h"
 #include "UICommon/ResourcePack/Manager.h"
 #include "UICommon/ResourcePack/Manifest.h"
 #include "UICommon/ResourcePack/ResourcePack.h"
@@ -2114,12 +2115,15 @@ void MainWindow::Show()
   }
   else if (!m_init_netplay_path.empty())
   {
-    //TODO: don't find game from game list here, find directly in GameFileCache?
-    // Want to load game whether it's folder has been added to game list or not
-    const auto game = m_game_list->FindGame(m_init_netplay_path);
-    if (game)
+    const auto gamePtr = [this]() {
+      UICommon::GameFileCache& cache = m_game_list->GetGameListModel().GetGameCache();
+      bool unusedCacheChanged{};
+      return cache.AddOrGet(m_init_netplay_path, &unusedCacheChanged);
+    }();
+
+    if (gamePtr)
     {
-      NetPlaySearch(*game);
+      NetPlaySearch(*gamePtr);
     }
     else
     {

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -205,8 +205,9 @@ static std::vector<std::string> StringListToStdVector(QStringList list)
 }
 
 MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
-                       const std::string& movie_path)
-    : QMainWindow(nullptr)
+                       const std::string& movie_path,
+                       std::string init_netplay_path)
+    : QMainWindow(nullptr), m_init_netplay_path(std::move(init_netplay_path))
 {
   qRegisterMetaType<std::shared_ptr<const UICommon::GameFile>>();
   qRegisterMetaType<UICommon::GameFile>("UICommon::GameFile");
@@ -2110,5 +2111,11 @@ void MainWindow::Show()
   {
     StartGame(std::move(m_pending_boot));
     m_pending_boot.reset();
+  }
+  else if (!m_init_netplay_path.empty())
+  {
+    //TODO: fix according to rapito's fix to null reference thing
+    auto game = m_game_list->FindGame(m_init_netplay_path);
+    NetPlaySearch(*game);
   }
 }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -117,7 +117,6 @@
 
 #include "UICommon/DiscordPresence.h"
 #include "UICommon/GameFile.h"
-#include "UICommon/GameFileCache.h"
 #include "UICommon/ResourcePack/Manager.h"
 #include "UICommon/ResourcePack/Manifest.h"
 #include "UICommon/ResourcePack/ResourcePack.h"
@@ -2115,12 +2114,7 @@ void MainWindow::Show()
   }
   else if (!m_init_netplay_path.empty())
   {
-    const auto gamePtr = [this]() {
-      UICommon::GameFileCache& cache = m_game_list->GetGameListModel().GetGameCache();
-      bool unusedCacheChanged{};
-      return cache.AddOrGet(m_init_netplay_path, &unusedCacheChanged);
-    }();
-
+    const auto gamePtr = m_game_list->GetGameListModel().AddOrGetFromCache(m_init_netplay_path);
     if (gamePtr)
     {
       NetPlaySearch(*gamePtr);

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -70,7 +70,8 @@ class MainWindow final : public QMainWindow
 
 public:
   explicit MainWindow(std::unique_ptr<BootParameters> boot_parameters,
-                      const std::string& movie_path);
+                      const std::string& movie_path,
+                      std::string init_netplay_path );
   ~MainWindow();
 
   void Show();
@@ -260,4 +261,5 @@ private:
   QByteArray m_render_widget_geometry;
   LylatMatchmakingClient* m_lylat_matchmaking_client = nullptr;
   ParallelProgressDialog* m_lylat_progress_dialog;
+  std::string m_init_netplay_path;
 };

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -87,6 +87,11 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
       .metavar("<file>")
       .type("string")
       .help("Load the specified file");
+  parser->add_option("-M", "--matchmaking")
+      .action("append")
+      .metavar("<file>")
+      .type("string")
+      .help("Launch lylat matchmaking with the specified file");
   parser->add_option("-n", "--nand_title")
       .action("store")
       .metavar("<16-character ASCII title ID>")

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -91,7 +91,7 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
       .action("append")
       .metavar("<file>")
       .type("string")
-      .help("Launch lylat matchmaking with the specified file");
+      .help("Launch lylat matchmaking with the specified game");
   parser->add_option("-n", "--nand_title")
       .action("store")
       .metavar("<16-character ASCII title ID>")


### PR DESCRIPTION
Adds a command line option (and button to create shortcut for Windows) for immediately starting netplay matchmaking with the specified game file.
Example: `dolphin.exe -M "G:\Some\Path\Project+ Launcher.elf"`

- Fixed bug where different path separators would cause game path to not match between default ISO and file in GameList
- Added some functions to GameList, model, tracker, to make it possible to add / get a file from cache, sidestepping the game list. Feel like I'm breaking some intended encapsulation with these classes, maybe there's a better way to do this.
