### PR TITLE
Fix linux build issues.

### DIFF
--- a/Source/Core/Core/Lylat/LylatMatchmakingClient.h
+++ b/Source/Core/Core/Lylat/LylatMatchmakingClient.h
@@ -23,6 +23,7 @@
 #include "picojson.h"
 
 #include <random>
+#include <functional>
 
 namespace UICommon
 {


### PR DESCRIPTION
* Append functional include to LylatMatchmakingClient.h to fix make erroring out due to a call to an undeclared call to std::function.